### PR TITLE
Ignoring cURL SSL validation (host name and self-signed certs)

### DIFF
--- a/sparqllib.php
+++ b/sparqllib.php
@@ -3,7 +3,7 @@
 ###############################
 # Christopher Gutteridge 2010
 #  cjg@ecs.soton.ac.uk
-#  LGPL License 
+#  LGPL License
 #  http://graphite.ecs.soton.ac.uk/sparqllib/
 #  https://github.com/cgutteridge/PHP-SPARQL-Lib
 ###############################
@@ -24,13 +24,13 @@ function sparql_field_name( $result, $i ) { return $result->field_name( $i ); }
 
 function sparql_fetch_all( $result ) { return $result->fetch_all(); }
 
-function sparql_get( $endpoint, $sparql ) 
-{ 
+function sparql_get( $endpoint, $sparql )
+{
 	$db = sparql_connect( $endpoint );
 	if( !$db ) { return; }
 	$result = $db->query( $sparql );
 	if( !$result ) { return; }
-	return $result->fetch_all(); 
+	return $result->fetch_all();
 }
 
 function _sparql_a_connection( $db )
@@ -47,7 +47,7 @@ function _sparql_a_connection( $db )
 	}
 	return $db;
 }
-		
+
 
 #	$timeout = 20;
 #	$old = ini_set('default_socket_timeout', $timeout);
@@ -85,7 +85,7 @@ class sparql_connection
 	}
 
 	function query( $query, $timeout=null )
-	{	
+	{
 		$prefixes = "";
 		foreach( $this->ns as $k=>$v )
 		{
@@ -94,8 +94,8 @@ class sparql_connection
 		$output = $this->dispatchQuery( $prefixes.$query, $timeout );
 		if( $this->errno ) { return; }
 		$parser = new xx_xml($output, 'contents');
-		if( $parser->error() ) 
-		{ 
+		if( $parser->error() )
+		{
 			$this->errno = -1; # to not clash with CURLOPT return; }
 			$this->error = $parser->error();
 			return;
@@ -110,7 +110,7 @@ class sparql_connection
 		if( $this->errno ) { return false; }
 
 		return true;
-	}	
+	}
 
 	function dispatchQuery( $sparql, $timeout=null )
 	{
@@ -132,8 +132,10 @@ class sparql_connection
 		curl_setopt($ch, CURLOPT_HTTPHEADER,array (
 			"Accept: application/sparql-results+xml"
 		));
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 
-		$output = curl_exec($ch);      
+		$output = curl_exec($ch);
 		$info = curl_getinfo($ch);
 		if(curl_errno($ch))
 		{
@@ -147,7 +149,7 @@ class sparql_connection
 			$this->error = 'URL returned no data';
 			return;
 		}
-		if( $info['http_code'] != 200) 
+		if( $info['http_code'] != 200)
 		{
 			$this->errno = $info['http_code'];
 			$this->error = 'Bad response, '.$info['http_code'].': '.$output;
@@ -163,7 +165,7 @@ class sparql_connection
 	####################################
 
 	# This section is very limited right now. I plan, in time, to
-	# caching so it can save results to a cache to save re-doing them 
+	# caching so it can save results to a cache to save re-doing them
 	# and many more capability options (suggestions to cjg@ecs.soton.ac.uk)
 
 	var $caps = array();
@@ -175,7 +177,7 @@ class sparql_connection
 		"max"=>"SELECT (MAX(?a) AS ?n) ?b ... GROUP BY ?b",
 		"sample"=>"SELECT (SAMPLE(?a) AS ?n) ?b ... GROUP BY ?b",
 		"load"=>"LOAD <...>",
-	); 
+	);
 
 	var $caps_cache;
 	var $caps_anysubject;
@@ -194,7 +196,7 @@ class sparql_connection
 
 	# return true if the endpoint supports a capability
 	# nb. returns false if connecion isn't authoriased to use the feature, eg LOAD
-	function supports( $code ) 
+	function supports( $code )
 	{
 		if( isset( $this->caps[$code] ) ) { return $this->caps[$code]; }
 		$was_cached = false;
@@ -244,9 +246,9 @@ class sparql_connection
 	{
 		if( !isset( $this->caps_anysubject ) )
 		{
-			$results = $this->query( 
+			$results = $this->query(
 			  "SELECT * WHERE { ?s ?p ?o } LIMIT 1" );
-			if( sizeof($results)) 
+			if( sizeof($results))
 			{
 				$row = $results->fetch_array();
 				$this->caps_anysubject = $row["s"];
@@ -255,62 +257,62 @@ class sparql_connection
 		return $this->caps_anysubject;
 	}
 
-	# return true if the endpoint supports SELECT 
-	function test_select() 
+	# return true if the endpoint supports SELECT
+	function test_select()
 	{
-		$output = $this->dispatchQuery( 
+		$output = $this->dispatchQuery(
 		  "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 1" );
 		return !isset( $this->errno );
 	}
 
 	# return true if the endpoint supports AS
-	function test_math_as() 
+	function test_math_as()
 	{
-		$output = $this->dispatchQuery( 
+		$output = $this->dispatchQuery(
 		  "SELECT (1+2 AS ?bar) WHERE { ?s ?p ?o } LIMIT 1" );
 		return !isset( $this->errno );
 	}
 
 	# return true if the endpoint supports AS
-	function test_constant_as() 
+	function test_constant_as()
 	{
-		$output = $this->dispatchQuery( 
+		$output = $this->dispatchQuery(
 		  "SELECT (\"foo\" AS ?bar) WHERE { ?s ?p ?o } LIMIT 1" );
 		return !isset( $this->errno );
 	}
 
-	# return true if the endpoint supports SELECT (COUNT(?x) as ?n) ... GROUP BY 
-	function test_count() 
+	# return true if the endpoint supports SELECT (COUNT(?x) as ?n) ... GROUP BY
+	function test_count()
 	{
 		# assumes at least one rdf:type predicate
 		$s = $this->anySubject();
 		if( !isset($s) ) { return false; }
-		$output = $this->dispatchQuery( 
+		$output = $this->dispatchQuery(
 		  "SELECT (COUNT(?p) AS ?n) ?o WHERE { <$s> ?p ?o } GROUP BY ?o" );
 		return !isset( $this->errno );
 	}
 
-	function test_max() 
+	function test_max()
 	{
 		$s = $this->anySubject();
 		if( !isset($s) ) { return false; }
-		$output = $this->dispatchQuery( 
+		$output = $this->dispatchQuery(
 		  "SELECT (MAX(?p) AS ?max) ?o WHERE { <$s> ?p ?o } GROUP BY ?o" );
 		return !isset( $this->errno );
 	}
 
-	function test_sample() 
+	function test_sample()
 	{
 		$s = $this->anySubject();
 		if( !isset($s) ) { return false; }
-		$output = $this->dispatchQuery( 
+		$output = $this->dispatchQuery(
 		  "SELECT (SAMPLE(?p) AS ?sam) ?o WHERE { <$s> ?p ?o } GROUP BY ?o" );
 		return !isset( $this->errno );
 	}
 
-	function test_load() 
+	function test_load()
 	{
-		$output = $this->dispatchQuery( 
+		$output = $this->dispatchQuery(
 		  "LOAD <http://graphite.ecs.soton.ac.uk/sparqllib/examples/loadtest.rdf>" );
 		return !isset( $this->errno );
 	}
@@ -380,7 +382,7 @@ class sparql_result
 
 
 # class xx_xml adapted code found at http://php.net/manual/en/function.xml-parse.php
-# class is cc-by 
+# class is cc-by
 # hello at rootsy dot co dot uk / 24-May-2008 09:30
 class xx_xml {
 
@@ -394,7 +396,7 @@ class xx_xml {
 	var $path;
 	var $looks_legit = false;
 	var $error;
-  
+
 	// either you pass url atau contents.
 	// Use 'url' or 'contents' for the parameter
 	var $type;
@@ -405,7 +407,7 @@ class xx_xml {
 		$this->url  = $url;
 		$this->parse();
 	}
-  
+
 	function error() { return $this->error; }
 
 	// parse XML data
@@ -423,7 +425,7 @@ class xx_xml {
 
 		if ($this->type == 'url') {
 			// if use type = 'url' now we open the XML with fopen
-		  
+
 			if (!($fp = fopen($this->url, 'rb'))) {
 				$this->error("Cannot open {$this->url}");
 			}
@@ -450,13 +452,13 @@ class xx_xml {
 				}
 			}
 		}
-		if( !$this->looks_legit ) 
+		if( !$this->looks_legit )
 		{
 			$this->error = "Didn't even see a sparql element, is this really an endpoint?";
 		}
 	}
 
-	function startXML($parser, $name, $attr)	
+	function startXML($parser, $name, $attr)
 	{
 		if( $name == "sparql" ) { $this->looks_legit = true; }
 		if( $name == "result" )


### PR DESCRIPTION
Recently I had problems when I tried to access a Sparql Endpoint with a self-signed SSL certificate. I added a cURL parameter to ignore this validation (line 135):

``` php
curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
```

The other changes are related to a removed extra-spaces. 
